### PR TITLE
Use logging utils

### DIFF
--- a/livebus/build.gradle
+++ b/livebus/build.gradle
@@ -59,7 +59,7 @@ ext {
     siteUrl = 'https://github.com/insacc/Livebus'
     gitUrl = 'https://github.com/insacc/Livebus.git'
 
-    libraryVersion = '0.2.1'
+    libraryVersion = '0.2.2'
 
     developerId = 'insac'
     developerName = 'Can Undeger'

--- a/livebus/src/main/java/com/insac/can/livebus/core/SingleLiveEvent.kt
+++ b/livebus/src/main/java/com/insac/can/livebus/core/SingleLiveEvent.kt
@@ -20,7 +20,7 @@ import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.Observer;
 import android.support.annotation.MainThread;
 import android.support.annotation.Nullable;
-import android.util.Log;
+import com.insac.can.livebus.utils.logWarningOnlyInDebug
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -36,13 +36,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 
 class SingleLiveEvent<T> : LiveEventBase<T>() {
-    private val TAG = "SingleLiveEvent"
     private val mPending = AtomicBoolean(false)
 
     @MainThread
     override fun observe(owner: LifecycleOwner, observer: Observer<T>) {
         if (hasActiveObservers()) {
-            Log.w(TAG, "Multiple observers registered but only one will be notified of changes.")
+           logWarningOnlyInDebug("Multiple observers registered but only one will be notified of changes.")
         }
 
         super.observe(owner, Observer {

--- a/livebus/src/main/java/com/insac/can/livebus/core/StickySingleLiveEvent.kt
+++ b/livebus/src/main/java/com/insac/can/livebus/core/StickySingleLiveEvent.kt
@@ -4,17 +4,16 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.Observer
 import android.support.annotation.MainThread
 import android.support.annotation.Nullable
-import android.util.Log
+import com.insac.can.livebus.utils.logWarningOnlyInDebug
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class StickySingleLiveEvent<T> : LiveEventBase<T>() {
-    private val TAG = "SingleLiveEvent"
     private val mPending = AtomicBoolean(false)
 
     @MainThread
     override fun observe(owner: LifecycleOwner, observer: Observer<T>) {
         if (hasActiveObservers()) {
-            Log.w(TAG, "Multiple observers registered but only one will be notified of changes.")
+            logWarningOnlyInDebug("Multiple observers registered but only one will be notified of changes.")
         }
 
         super.observe(owner, Observer {


### PR DESCRIPTION
- Use logger utils function whenever necessary.
- This way we can have a more streamlined logging process